### PR TITLE
Naive trajectory planning based on plain interpolation of lane-coefficients

### DIFF
--- a/msg/Trajectory.msg
+++ b/msg/Trajectory.msg
@@ -1,6 +1,6 @@
 Header header
 
-# y coords [m]
+# x coords [m]
 float64[] x
 # y coords [m]
 float64[] y

--- a/nodes/planning_node.py
+++ b/nodes/planning_node.py
@@ -13,7 +13,7 @@ import tf
 
 from car_demo.msg import LaneCoefficients, Trajectory, TrafficLightStatus
 from geometry_msgs.msg import Point, Vector3, Quaternion
-from std_msgs.msg import ColorRGBA
+from std_msgs.msg import ColorRGBA, Header
 from tf.transformations import quaternion_from_euler
 from visualization_msgs.msg import MarkerArray, Marker
 
@@ -102,10 +102,10 @@ def create_trajectory(
 
 
 def create_debug_marker(
-    id: int, x: float, y: float, yaw: float, arrow_size: float = 0.5
+    id: int, x: float, y: float, yaw: float, header: Header, arrow_size: float = 0.5
 ) -> Marker:
     marker = Marker()
-    marker.header = trajectory.header
+    marker.header = header
     marker.id = id
     marker.action = Marker.ADD
     marker.type = Marker.ARROW
@@ -149,7 +149,9 @@ if __name__ == "__main__":
 
             marker_array = MarkerArray()
             marker_array.markers = [
-                create_debug_marker(i, x, y, th, arrow_size=STEP_SIZE)
+                create_debug_marker(
+                    i, x, y, th, trajectory.header, arrow_size=STEP_SIZE
+                )
                 for i, (x, y, th) in enumerate(
                     zip(trajectory.x, trajectory.y, trajectory.theta)
                 )

--- a/nodes/planning_node.py
+++ b/nodes/planning_node.py
@@ -9,10 +9,16 @@ angles and velocity associated) the vehicle should follow.
 
 import numpy as np
 import rospy
-import std_msgs.msg
 import tf
 
 from car_demo.msg import LaneCoefficients, Trajectory, TrafficLightStatus
+from geometry_msgs.msg import Point, Vector3, Quaternion
+from std_msgs.msg import ColorRGBA
+from tf.transformations import quaternion_from_euler
+from visualization_msgs.msg import MarkerArray, Marker
+
+MAX_DIST = 50
+STEP_SIZE = 0.5
 
 
 class LaneCoefficientsHandler:
@@ -20,13 +26,12 @@ class LaneCoefficientsHandler:
     A class to subscribe to lane coefficient updates and print received data.
     """
 
-    # TODO: replace handler behavior with proper trajectory planning
-
     def __init__(self):
         # subscribe to lane coefficient updates
-        self.lane_coeff_sub = rospy.Subscriber(
+        self._lane_coeff_sub = rospy.Subscriber(
             "lane_coefficients", LaneCoefficients, self._callback, queue_size=1
         )
+        self.latest_lane_coeff: LaneCoefficients = None
 
     def _callback(self, message: LaneCoefficients):
         rospy.loginfo(
@@ -36,6 +41,7 @@ class LaneCoefficientsHandler:
             f"dPhi={message.dPhi:.3f}, "
             f"c0={message.c0:.3f}"
         )
+        self.latest_lane_coeff = message
 
 
 class TrafficLightHandler:
@@ -43,15 +49,14 @@ class TrafficLightHandler:
     A class to subscribe to traffic light status and print received data.
     """
 
-    # TODO: replace handler behavior with proper trajectory planning
-
     def __init__(self):
         # subscribe to traffic light status
-        self.traffic_light_sub = rospy.Subscriber(
+        self._traffic_light_sub = rospy.Subscriber(
             "traffic_light_status", TrafficLightStatus, self._callback, queue_size=1
         )
+        self.latest_traffic_light_status: TrafficLightStatus = None
 
-    def _callback(self, message):
+    def _callback(self, message: TrafficLightStatus):
         state_dict = {
             message.GREEN: "GREEN",
             message.YELLOW: "YELLOW",
@@ -64,6 +69,52 @@ class TrafficLightHandler:
             f"dist={message.dist_m:.1f}m, "
             f"dphi={message.dphi_rad * 180.0 / np.pi:.1f}deg"
         )
+        self.latest_traffic_light_status = message
+
+
+def create_trajectory(
+    lane_coeff: LaneCoefficients, max_dist: float = 50, step: float = 0.5
+) -> Trajectory:
+    x = np.arange(0, max_dist, step)
+    y = np.empty_like(x)
+    Z = np.array([lane_coeff.W, lane_coeff.Y_offset, lane_coeff.dPhi, lane_coeff.c0])
+
+    for i, u in enumerate(x):
+        u2 = u ** 2
+        y[i] = np.dot(np.array([0, -1, -u, 0.5 * u2]), Z)
+
+    delta = np.diff(np.column_stack((x, y)), axis=0)
+    theta = np.pad(np.arctan2(delta[:, 1], delta[:, 0]), pad_width=(0, 1), mode="edge")
+    c = np.pad(np.diff(theta) / step, pad_width=(0, 1), mode="edge")
+    velocity = np.full_like(x, 3)  # static velocity
+    s = np.linalg.norm(delta)
+
+    trajectory = Trajectory()
+    trajectory.header = lane_coeff.header
+    trajectory.header.frame_id = "base_link"
+    trajectory.x = x
+    trajectory.y = y
+    trajectory.theta = theta
+    trajectory.c = c
+    trajectory.v = velocity
+    trajectory.s = s
+    return trajectory
+
+
+def create_debug_marker(
+    id: int, x: float, y: float, yaw: float, arrow_size: float = 0.5
+) -> Marker:
+    marker = Marker()
+    marker.header = trajectory.header
+    marker.id = id
+    marker.action = Marker.ADD
+    marker.type = Marker.ARROW
+    marker.pose.position = Point(x=x, y=y)
+    q = quaternion_from_euler(0, 0, yaw)
+    marker.pose.orientation = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
+    marker.color = ColorRGBA(r=1, g=0, b=0, a=1)
+    marker.scale = Vector3(x=arrow_size, y=arrow_size * 0.1, z=arrow_size * 0.1)
+    return marker
 
 
 if __name__ == "__main__":
@@ -75,6 +126,7 @@ if __name__ == "__main__":
 
     # publishers
     trajectory_pub = rospy.Publisher("trajectory", Trajectory, queue_size=1)
+    trajectory_dbg_pub = rospy.Publisher("trajectory_dbg", MarkerArray, queue_size=1)
 
     # setup lane coefficients handler
     lane_coeff_handler = LaneCoefficientsHandler()
@@ -83,22 +135,26 @@ if __name__ == "__main__":
     traffic_light_handler = TrafficLightHandler()
 
     # main loop
-    time_start = rospy.Time(0)
     while not rospy.is_shutdown():
-        time_now = rospy.get_rostime()
-        if time_start == rospy.Time(0):
-            time_start = time_now
+        # Naive trajectory planning, based souley on interpolating the
+        # LaneCoefficients until a traffic light is found.
 
-        # TODO: fill message object with proper values
-        trajectory = Trajectory()
-        trajectory.header = std_msgs.msg.Header()
-        trajectory.x = 0
-        trajectory.y = 0
-        trajectory.theta = 0
-        trajectory.c = 0
-        trajectory.v = 0
-        trajectory.s = 0
+        lane_coeff = lane_coeff_handler.latest_lane_coeff
 
-        trajectory_pub.publish(trajectory)
+        if lane_coeff is not None:
+            trajectory = create_trajectory(
+                lane_coeff, max_dist=MAX_DIST, step=STEP_SIZE
+            )
+            trajectory_pub.publish(trajectory)
+
+            marker_array = MarkerArray()
+            marker_array.markers = [
+                create_debug_marker(i, x, y, th, arrow_size=STEP_SIZE)
+                for i, (x, y, th) in enumerate(
+                    zip(trajectory.x, trajectory.y, trajectory.theta)
+                )
+            ]
+
+            trajectory_dbg_pub.publish(marker_array)
 
         rate.sleep()

--- a/nodes/planning_node.py
+++ b/nodes/planning_node.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
 
     # main loop
     while not rospy.is_shutdown():
-        # Naive trajectory planning, based souley on interpolating the
+        # Naive trajectory planning, based solely on interpolating the
         # LaneCoefficients until a traffic light is found.
 
         lane_coeff = lane_coeff_handler.latest_lane_coeff


### PR DESCRIPTION
Very simple trajectory planning by simply interpolating the lane-coefficients from 0m to 50m distance.

Tested with lane coefficients generated by M-Estimator from ASD-Assignment 4.
```python
#             W,              Y_offset,         dPhi,           c0
Z = np.array([3.87941135e+00, -2.23673848e-01,  7.92441694e-03, -1.00613115e-03])
```

I also implemented a `/trajectory_dbg` endpoint, that publishes a `MarkerArray` of vectors along the trajectory. Can be displayed in rviz: Display > hit "Add" > select "By topic" > "/trajectory_dbg" > select "MarkerArray" > hit "OK".