### PR TITLE
Replace meta-pkg dep vision_opencv with children

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,12 +14,13 @@
   <depend>gazebo_ros</depend>
   <depend>urdf</depend>
 
+  <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
+  <depend>image_geometry</depend>
   <depend>python3-tk</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>vision_opencv</depend>
 
   <exec_depend>fake_localization</exec_depend>
   <exec_depend>joy</exec_depend>


### PR DESCRIPTION
Fixes `catkin_make` warning during build:
```text
WARNING: package "car_demo" should not depend on metapackage "vision_opencv" but on its packages instead
```