### PR TITLE
Add requirements.txt to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+    - package-ecosystem: "pip"
+      directory: "/.devcontainer"
+      schedule:
+          interval: "weekly"


### PR DESCRIPTION
This configures dependabot to monitor `requirements.txt` for new versions of each package. Once new versions are detected, dependabot will raise a PR for us to review. Helps keeping up-to-date with latest tools.