### PR TITLE
Init catkin workspace only if it doesn't already exist

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -5,6 +5,6 @@ source /opt/ros/$ROS_DISTRO/setup.bash
 
 sudo chown vscode:vscode /workspace /workspace/src
 
-mkdir -p /workspace/src && cd /workspace/src && catkin_init_workspace
+mkdir -p /workspace/src && [ -f /workspace/src/CMakeLists.txt ] || cd /workspace/src && catkin_init_workspace
 
 exec "$@"


### PR DESCRIPTION
Previously, "hot-starting" the docker devcontainer failed due to an error in `entrypoint.sh`, which stopped the container early. This resulted in vscode being unable to load the workspace.

This PR should fix the bug that caused `entrypoint.sh` to fail, by checking if a `CMakeLists.txt` exists and only calling `catkin_init_workspace` if it doesn't. Thus IDE start-up time will be greatly reduced.

@sunny-5555 @Braafisch To apply this change on your local system please rebuild the container once (`Ctrl + P` > `>Remote-Containers: Rebuild Container`).