### PR TITLE
Fix check for existing workspace

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -5,6 +5,6 @@ source /opt/ros/$ROS_DISTRO/setup.bash
 
 sudo chown vscode:vscode /workspace /workspace/src
 
-mkdir -p /workspace/src && [ -f /workspace/src/CMakeLists.txt ] || cd /workspace/src && catkin_init_workspace
+mkdir -p /workspace/src && ([ -f /workspace/src/CMakeLists.txt ] || catkin_init_workspace /workspace/src)
 
 exec "$@"


### PR DESCRIPTION
Had a bug in my shell script, causing vscode to be unable to connect to the devcontainer.

This PR fixes the conditional logic in `entrypoint.sh`, which checks for an existing workspace.