### PR TITLE
Create .gitattributes to force LF on shell files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.bash text eol=lf
+*.zsh text eol=lf


### PR DESCRIPTION
On Windows git may store `.sh` and similar shell files with `<CR><LF>` line endings. This causes issues when the devcontainer (which is running Linux) tries to interpret these scripts.
This git-attribute will force git to use `<LF>` line endings on all shell-type files.

Windows users that run this project in a devcontainer may also want to set git-config `core.autocrlf` to `false`.
To set it locally for this repository:
```powershell
git config --local core.autocrlf false
```
Or globally
```powershell
git config --global core.autocrlf false
```